### PR TITLE
Update gpu_node_queue_and_policy.md

### DIFF
--- a/doc_staging/gpu_node_queue_and_policy.md
+++ b/doc_staging/gpu_node_queue_and_policy.md
@@ -37,7 +37,7 @@ Initially, we are relaxing our node restrictions to encourage early users.  Plea
 Here are the initial queue limits:
 
  - `MinTime` is 5 minutes
- - `MaxTime` is 24 hours
+ - `MaxTime` is 12 hours
  - `MaxRunning` will be 2 full nodes or 16 individual GPUs
 
 ### Queue Restrictions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: Theta GPU Documentation
 nav:
   - Home: index.md
+  - System Overview and Node Information: system_overview_and_node_information.md
+  - GPU Node Queues and Policy: gpu_node_queue_and_policy.md
   - GPU Monitoring: GPU Monitoring.md
   - Building Python Packages: building_python_packages.md
   - MPI: mpi.md
@@ -10,6 +12,9 @@ nav:
       - Running with Singularity: ml_frameworks/tensorflow/nvidia_container_notes.md
       - Running with Conda: ml_frameworks/tensorflow/running_with_conda.md
       - Tensorboard: ml_frameworks/tensorflow/tensorboard_instructions.md
+  - Building and Compiling: 
+    - Python/C++ code interoperability: Building_Compiling/README.md
+    - Compiling and Linking: Building_Compiling/compiling_and_linking.md
 
 docs_dir: 'doc_staging/'
 site_dir: 'docs/'


### PR DESCRIPTION
Change `MaxTime` from 24 to 12 hours.

```bash
$ qsub -I -A datascience -n 1 -t 24:00 -O interactive --attrs=pubnet=true

Job routed to queue "full-node".
No handlers could be found for logger "Proxy"
<Fault 1001: "Walltime greater than the 'full-node' queue max walltime of 12:00:00\n">
```