### PR TITLE
updated documentation for DeepHyper 0.2.5 on ThetaGPU

### DIFF
--- a/doc_staging/deephyper.md
+++ b/doc_staging/deephyper.md
@@ -1,22 +1,21 @@
 # DeepHyper
 
-!!! warning "Experimental"
-    DeepHyper support on ThetaGPU is under active development and testing.  Currently,
-    only single node runs using `--evaluator subprocess` have been tested.
+For more details refer to the [DeepHyper documentation](https://deephyper.readthedocs.io/en/latest/index.html).
 
-A Python environment with DeepHyper installation can be obtained  by sourcing the setup script:
+## Installation
 
-```bash
-source /lus/theta-fs0/software/thetagpu/balsam/setup.sh
-```
+The installation procedure of DeepHyper on ThetaGPU can be found on the official documentation of the software ["Installing DeepHyper on ThetaGPU](https://deephyper.readthedocs.io/en/latest/install/thetagpu.html).
 
-From a ThetaGPU compute node, you may then initiate a local hyperparameter search using the `subprocess` evaluator.  For instance:
+## Example
+
+From a ThetaGPU login node, you may then initiate an hyperparameter search using the `ray` evaluator through the `ray-submit` command line.  For instance:
 
 ```bash
 deephyper start-project hps_demo
 cd hps_demo/hps_demo
 deephyper new-problem hps polynome2
-deephyper hps ambs --problem hps_demo.polynome2.problem.Problem --run hps_demo.polynome2.model_run.run --evaluator subprocess
+mkdir exp && cd exp/
+deephyper ray-submit hps ambs -w test_polynome2 -n 1 -t 15 -A datascience -q full-node -as ../SetUpEnv.sh -p hps_demo.polynome2.problem.Problem -r hps_demo.polynome2.model_run.run --max-evals 10 --num-cpus-per-task 1 --num-gpus-per-task 1 --n-jobs 16
 ```
 
-For more details refer to the [deephyper documentation](https://deephyper.readthedocs.io/en/latest/index.html).
+For more details about how to use DeepHyper on ThetaGPU we refer to the official documentation of the software ["Running on ThetaGPU (ACLF)"](https://deephyper.readthedocs.io/en/latest/index.html).

--- a/doc_staging/deephyper.md
+++ b/doc_staging/deephyper.md
@@ -8,7 +8,7 @@ The installation procedure of DeepHyper on ThetaGPU can be found on the official
 
 ## Example
 
-From a ThetaGPU login node, you may then initiate an hyperparameter search using the `ray` evaluator through the `ray-submit` command line.  For instance:
+From a ThetaGPU service node (e.g. `thetagpusn1`), you may then initiate a hyperparameter search using the `ray` evaluator through the `ray-submit` command line.  For instance:
 
 ```bash
 deephyper start-project hps_demo


### PR DESCRIPTION
Hello @felker, 

I updated the documentation page of DeepHyper on this repo. However, I don't have the rights to create a custom module on ThetaGPU could someone follow the [new installation procedure](https://deephyper.readthedocs.io/en/latest/install/thetagpu.html#user-installation) and provide a DeepHyper module on ThetaGPU?